### PR TITLE
Add SerializationCatchError example

### DIFF
--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -202,13 +202,26 @@ jobs:
     name: "Transform And Store component test"
     needs: should-run
     runs-on: ubuntu-latest
-    if: ${{ needs.should-run.outputs.event-name-check == 'true' || needs.should-run.outputs.tag-check == 'true' }}
+    if: ${{ needs.should-run.outputs.should-run }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build Transfrom And Store example image and run component test
+      - name: Transform And Store - Check if files has changed
+        uses: tj-actions/changed-files@v40
+        id: changed-files
+        with: 
+          files: |
+            TransformAndStore/ComponentTest/**
+            TransformAndStore/src/**
+            TransformAndStore/.ignore
+            TransformAndStore/*.yaml
+            TransformAndStore/Dockerfile
+            TransformAndStore/*.xml
+
+      - name: Build Transform And Store example image and run component test
         uses: ./.github/actions/component-test
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         with:
           context-path: ./TransformAndStore/
           access-token: ${{ secrets.PACKAGE_PAT }}
@@ -218,13 +231,26 @@ jobs:
     name: "Serialization Error Catch component test"
     needs: should-run
     runs-on: ubuntu-latest
-    if: ${{ needs.should-run.outputs.event-name-check == 'true' || needs.should-run.outputs.tag-check == 'true' }}
+    if: ${{ needs.should-run.outputs.should-run }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Serialization Error Catch - Check if files has changed
+        uses: tj-actions/changed-files@v40
+        id: changed-files
+        with: 
+          files: |
+            SerializationErrorCatch/ComponentTest/**
+            SerializationErrorCatch/src/**
+            SerializationErrorCatch/.ignore
+            SerializationErrorCatch/*.yaml
+            SerializationErrorCatch/Dockerfile
+            SerializationErrorCatch/*.xml
+
       - name: Build Serialization Error Catch example image and run component test
         uses: ./.github/actions/component-test
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         with:
           context-path: ./SerializationErrorCatch/
           access-token: ${{ secrets.PACKAGE_PAT }}

--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -213,3 +213,19 @@ jobs:
           context-path: ./TransformAndStore/
           access-token: ${{ secrets.PACKAGE_PAT }}
           initial-kafka-topics: "TransfromAndStoreInputTopic"
+
+  serilization-error-catch-component-test:
+    name: "Serilization Error Catch component test"
+    needs: should-run
+    runs-on: ubuntu-latest
+    if: ${{ needs.should-run.outputs.event-name-check == 'true' || needs.should-run.outputs.tag-check == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Serilization Error Catch example image and run component test
+        uses: ./.github/actions/component-test
+        with:
+          context-path: ./SerilizationErrorCatch/
+          access-token: ${{ secrets.PACKAGE_PAT }}
+          initial-kafka-topics: "SerializationErrorCatchInputTopic"

--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -214,8 +214,8 @@ jobs:
           access-token: ${{ secrets.PACKAGE_PAT }}
           initial-kafka-topics: "TransfromAndStoreInputTopic"
 
-  serilization-error-catch-component-test:
-    name: "Serilization Error Catch component test"
+  serialization-error-catch-component-test:
+    name: "Serialization Error Catch component test"
     needs: should-run
     runs-on: ubuntu-latest
     if: ${{ needs.should-run.outputs.event-name-check == 'true' || needs.should-run.outputs.tag-check == 'true' }}
@@ -223,9 +223,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build Serilization Error Catch example image and run component test
+      - name: Build Serialization Error Catch example image and run component test
         uses: ./.github/actions/component-test
         with:
-          context-path: ./SerilizationErrorCatch/
+          context-path: ./SerializationErrorCatch/
           access-token: ${{ secrets.PACKAGE_PAT }}
           initial-kafka-topics: "SerializationErrorCatchInputTopic"

--- a/.github/workflows/maven-build-and-test.yml
+++ b/.github/workflows/maven-build-and-test.yml
@@ -105,15 +105,15 @@ jobs:
           settings-path: ./TransformAndStore/
           access-token: ${{ secrets.PACKAGE_PAT }}
   
-  serilization-error-catch-build-and-test:
-    name: "Serilization Error Catch - Build and Test"
+  serialization-error-catch-build-and-test:
+    name: "Serialization Error Catch - Build and Test"
     runs-on: ubuntu-latest
     steps: 
       - name: Checkout repository
         uses: actions/checkout@v4
       
-      - name: Serilization Error Catch - Build and Test
+      - name: Serialization Error Catch - Build and Test
         uses: ./.github/actions/maven-build-and-test
         with: 
-          settings-path: ./SerilizationErrorCatch/
+          settings-path: ./SerializationErrorCatch/
           access-token: ${{ secrets.PACKAGE_PAT }}

--- a/.github/workflows/maven-build-and-test.yml
+++ b/.github/workflows/maven-build-and-test.yml
@@ -104,3 +104,16 @@ jobs:
         with: 
           settings-path: ./TransformAndStore/
           access-token: ${{ secrets.PACKAGE_PAT }}
+  
+  serilization-error-catch-build-and-test:
+    name: "Serilization Error Catch - Build and Test"
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Serilization Error Catch - Build and Test
+        uses: ./.github/actions/maven-build-and-test
+        with: 
+          settings-path: ./SerilizationErrorCatch/
+          access-token: ${{ secrets.PACKAGE_PAT }}

--- a/SerializationErrorCatch/ComponentTest/.dockerignore
+++ b/SerializationErrorCatch/ComponentTest/.dockerignore
@@ -1,0 +1,4 @@
+/bin
+/obj
+Dockerfile
+*.sln

--- a/SerializationErrorCatch/ComponentTest/ComponentTest.cs
+++ b/SerializationErrorCatch/ComponentTest/ComponentTest.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cheetah.ComponentTest.Kafka;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Observability.ComponentTest.PrometheusMetrics;
+using Xunit;
+using SerializationErrorCatch.ComponentTest.Models;
+
+namespace SerializationErrorCatch.ComponentTest;
+
+[Trait("TestType", "IntegrationTests")]
+public class ComponentTest
+{
+    readonly IConfiguration _configuration;
+
+    public ComponentTest()
+    {
+        // These will be overriden by environment variables from compose
+        var conf = new Dictionary<string, string>()
+        {
+            {"KAFKA:AUTHENDPOINT", "http://localhost:1752/oauth2/token"},
+            {"KAFKA:CLIENTID", "ClientId" },
+            {"KAFKA:CLIENTSECRET", "1234" },
+            {"KAFKA:URL", "localhost:9092"}
+        };
+        _configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(conf)
+            .AddEnvironmentVariables()
+            .Build();
+    }
+
+    [Fact]
+    public async Task Should_BeImplemented_When_ServiceIsCreated()
+    {
+        // Arrange
+        // Here you'll set up one or more writers and readers, which connect to the topic(s) that your job consumes
+        // from and publishes to. 
+        var writer = KafkaWriterBuilder.Create<string, InputEvent>(_configuration)
+            .WithTopic("SerializationErrorCatchInputTopic") // The topic to consume from
+            .WithKeyFunction(model => model.DeviceId) // Optional function to retrieve the message key.
+                                                          // If no key is desired, use KafkaWriterBuilder.Create<Null, InputModel>
+                                                          // and make this function return null
+            .Build();
+
+        var badWriter = KafkaWriterBuilder.Create<string, BadEvent>(_configuration)
+            .WithTopic("SerializationErrorCatchInputTopic") // The topic to consume from
+            .WithKeyFunction(model => model.DeviceId) // Optional function to retrieve the message key.
+            // If no key is desired, use KafkaWriterBuilder.Create<Null, InputModel>
+            // and make this function return null
+            .Build();
+        
+        var reader = KafkaReaderBuilder.Create<string, OutputEvent>(_configuration)
+            .WithTopic("SerializationErrorCatchOutputTopic")     // The topic being published to from the job
+            .WithConsumerGroup("MyGroup")           // The consumer group used for reading from the topic
+            .Build();
+        
+        var metricsReader = new PrometheusMetricsReader("serializationerrorcatch-taskmanager", 9249);
+        
+        // Act
+        // Write one or more messages to the writer
+        var inputEvent = new InputEvent()
+        {
+            DeviceId = "deviceId-1",
+            Value = 12.34,
+            Timestamp = DateTimeOffset.UnixEpoch.ToUnixTimeMilliseconds()
+        };
+        
+        var badInputEvent = new BadEvent()
+        {
+            DeviceId = "deviceId-1",
+            Value = 111.34,
+            Timestamp = DateTimeOffset.UnixEpoch.ToUnixTimeMilliseconds(),
+            BadField = "BadFieldValue"
+        };
+        
+        await writer.WriteAsync(inputEvent);
+        await badWriter.WriteAsync(badInputEvent);
+        
+        //Wait, to ensure processing is done
+        await Task.Delay(TimeSpan.FromSeconds(20));
+        
+        var gauge = await metricsReader.GetCounterValueAsync("FailedMessagesProcessed");
+        Assert.Equal(1, gauge);
+        
+        // Assert 
+        // Then consume using the reader, supplying how many output messages your input messages expected to generate
+        // as well as the maximum duration it is allowed to take for those messages to be produced
+        var messages = reader.ReadMessages(1, TimeSpan.FromSeconds(20));
+        
+        // Then evaluate whether your messages are as expected, and that there are only as many as you expected 
+        messages.Should().ContainSingle(message => 
+            message.DeviceId == inputEvent.DeviceId && 
+            message.Value == inputEvent.Value &&
+            message.Timestamp == inputEvent.Timestamp &&
+            message.ExtraField == "ExtraFieldValue");
+        reader.VerifyNoMoreMessages(TimeSpan.FromSeconds(20)).Should().BeTrue();
+    }
+}

--- a/SerializationErrorCatch/ComponentTest/Dockerfile
+++ b/SerializationErrorCatch/ComponentTest/Dockerfile
@@ -1,0 +1,17 @@
+﻿FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+
+WORKDIR /src
+COPY "NuGet-CI.Config" "NuGet.Config"
+COPY . .
+RUN \
+    --mount=type=secret,id=GITHUB_ACTOR \
+    --mount=type=secret,id=GITHUB_TOKEN \
+    GITHUB_ACTOR="$(cat /run/secrets/GITHUB_ACTOR)" \
+    GITHUB_TOKEN="$(cat /run/secrets/GITHUB_TOKEN)" \
+    dotnet restore "SerializationErrorCatch.ComponentTest.csproj"
+
+USER $APP_UID
+ENTRYPOINT ["dotnet","test", "SerializationErrorCatch.ComponentTest.csproj", "--no-restore"]

--- a/SerializationErrorCatch/ComponentTest/Models/BadEvent.cs
+++ b/SerializationErrorCatch/ComponentTest/Models/BadEvent.cs
@@ -1,0 +1,15 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SerializationErrorCatch.ComponentTest.Models;
+
+public class BadEvent
+{
+    [JsonPropertyName("deviceId")]
+    public string DeviceId { get; set; }
+    [JsonPropertyName("value")]
+    public double Value { get; set; }
+    [JsonPropertyName("timestamp")]
+    public long Timestamp { get; set; }
+    [JsonPropertyName("badField")] 
+    public string BadField { get; set; }
+}

--- a/SerializationErrorCatch/ComponentTest/Models/InputEvent.cs
+++ b/SerializationErrorCatch/ComponentTest/Models/InputEvent.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SerializationErrorCatch.ComponentTest.Models;
+
+// Rename and implement a model that fits what your job expects to receive
+public class InputEvent
+{
+    [JsonPropertyName("deviceId")]
+    public string DeviceId { get; set; }
+
+    [JsonPropertyName("value")]
+    public double Value { get; set; }
+
+    [JsonPropertyName("timestamp")]
+    public long Timestamp { get; set; }
+}

--- a/SerializationErrorCatch/ComponentTest/Models/OutputEvent.cs
+++ b/SerializationErrorCatch/ComponentTest/Models/OutputEvent.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SerializationErrorCatch.ComponentTest.Models;
+
+// Rename and implement a model that fits the one you expect your job to produce
+public class OutputEvent
+{
+    [JsonPropertyName("deviceId")]
+    public string DeviceId { get; set; }
+
+    [JsonPropertyName("value")]
+    public double Value { get; set; }
+
+    [JsonPropertyName("timestamp")]
+    public long Timestamp { get; set; }
+
+    [JsonPropertyName("extraField")]
+    public string ExtraField { get; set; }
+}

--- a/SerializationErrorCatch/ComponentTest/NuGet-CI.Config
+++ b/SerializationErrorCatch/ComponentTest/NuGet-CI.Config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="trifork-github" value="https://nuget.pkg.github.com/trifork/index.json" />
+  </packageSources>
+<packageSourceCredentials>
+      <trifork-github>
+        <add key="Username" value="%GITHUB_ACTOR%" />
+        <add key="ClearTextPassword" value="%GITHUB_TOKEN%" />
+      </trifork-github>
+    </packageSourceCredentials>
+</configuration>

--- a/SerializationErrorCatch/ComponentTest/SerializationErrorCatch.ComponentTest.csproj
+++ b/SerializationErrorCatch/ComponentTest/SerializationErrorCatch.ComponentTest.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Cheetah.ComponentTest" Version="1.6.3" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="xunit" Version="2.6.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+</Project>

--- a/SerializationErrorCatch/ComponentTest/SerializationErrorCatch.ComponentTest.sln
+++ b/SerializationErrorCatch/ComponentTest/SerializationErrorCatch.ComponentTest.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerializationErrorCatch.ComponentTest", "SerializationErrorCatch.ComponentTest.csproj", "{D4076218-47CC-4A9D-99E2-73FA3EDBFD99}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D4076218-47CC-4A9D-99E2-73FA3EDBFD99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4076218-47CC-4A9D-99E2-73FA3EDBFD99}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4076218-47CC-4A9D-99E2-73FA3EDBFD99}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4076218-47CC-4A9D-99E2-73FA3EDBFD99}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/SerializationErrorCatch/ComponentTest/SerializationErrorCatch.ComponentTest.sln.DotSettings.user
+++ b/SerializationErrorCatch/ComponentTest/SerializationErrorCatch.ComponentTest.sln.DotSettings.user
@@ -1,0 +1,16 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=684a86bb_002D4b20_002D4034_002Dacde_002D12c99407d624/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Should_BeImplemented_When_ServiceIsCreated #3" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;xUnit::D4076218-47CC-4A9D-99E2-73FA3EDBFD99::net6.0::SerializationErrorCatch.ComponentTest.ComponentTest.Should_BeImplemented_When_ServiceIsCreated&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=8ea156e3_002De85d_002D4cd0_002Db195_002D04913f6694d4/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Should_BeImplemented_When_ServiceIsCreated #2" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;xUnit::D4076218-47CC-4A9D-99E2-73FA3EDBFD99::net6.0::SerializationErrorCatch.ComponentTest.ComponentTest.Should_BeImplemented_When_ServiceIsCreated&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=8f2281dc_002Db2d4_002D468c_002D803c_002D2a0b478f0512/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Should_BeImplemented_When_ServiceIsCreated" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;xUnit::D4076218-47CC-4A9D-99E2-73FA3EDBFD99::net6.0::SerializationErrorCatch.ComponentTest.ComponentTest.Should_BeImplemented_When_ServiceIsCreated&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/SerializationErrorCatch/ComponentTest/global.json
+++ b/SerializationErrorCatch/ComponentTest/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "6.0.416",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}

--- a/SerializationErrorCatch/Dockerfile
+++ b/SerializationErrorCatch/Dockerfile
@@ -1,0 +1,63 @@
+#
+#  Install dependencies, compile sources, build jars.
+#
+FROM maven:3.8.6-openjdk-11 as build
+
+WORKDIR /app
+
+ARG MAVEN_ARGS
+
+COPY pom.xml ./
+COPY settings.xml ./
+# Copy in local repository
+COPY .m2/ /root/.m2/
+
+# Download all dependencies, excluding the ones marked as 'provided';
+# Change scope of Flink dependencies from 'compile' to 'provided'.
+# This basically instructs Maven to not download the jar files,
+# but rely on them being provided by other means,
+# and effectively results in a fat har without Flink jars.
+# This is because the runtime docker container provides the Flink jars
+# itself and adds them on the classpath for the fat jar to resolve.
+RUN sed -i pom.xml -e 's,<scope>compile</scope>,<scope>provided</scope>,'
+
+# Download dependencies (with docker cache)
+RUN \
+    --mount=type=secret,id=GITHUB_TOKEN \
+    --mount=type=secret,id=GITHUB_ACTOR \
+    --mount=type=cache,target=./.m2,sharing=locked \
+    cp -rn /root/.m2/ ./ &&\
+    GITHUB_TOKEN="$(cat /run/secrets/GITHUB_TOKEN)" \
+    GITHUB_ACTOR="$(cat /run/secrets/GITHUB_ACTOR)" \
+    mvn dependency:resolve dependency:resolve-plugins -B -U -s ./settings.xml -Dmaven.repo.local="${CI_PROJECT_DIR-.}"/.m2/repository
+
+# Then add source.
+COPY src ./src
+
+# Finally compile, test, and jar up
+RUN \
+    --mount=type=secret,id=GITHUB_TOKEN \
+    --mount=type=secret,id=GITHUB_ACTOR \
+    --mount=type=cache,target=./.m2,sharing=locked \
+    GITHUB_TOKEN="$(cat /run/secrets/GITHUB_TOKEN)" \
+    GITHUB_ACTOR="$(cat /run/secrets/GITHUB_ACTOR)" \
+    mvn package -B -s ./settings.xml ${MAVEN_ARGS-} -Dmaven.repo.local="${CI_PROJECT_DIR-.}"/.m2/repository
+
+#
+#  Install jars onto clean runtime system.
+#
+FROM flink:1.16.1-scala_2.12-java11 as runtime
+
+COPY --from=build /app/target/lib/*.jar /opt/flink/usrlib/artifacts/
+COPY --from=build /app/target/SerializationErrorCatch*.jar /opt/flink/usrlib/artifacts/
+
+RUN mkdir /opt/flink/plugins/s3-fs-hadoop/; \
+    mkdir /opt/flink/plugins/s3-fs-presto/; \
+    mkdir ./plugins/azure-fs-hadoop; \
+    cp /opt/flink/opt/flink-s3-fs-hadoop-1.16.1.jar /opt/flink/plugins/s3-fs-hadoop/; \
+    cp /opt/flink/opt/flink-s3-fs-presto-1.16.1.jar /opt/flink/plugins/s3-fs-presto/; \
+    cp ./opt/flink-azure-fs-hadoop-1.16.1.jar ./plugins/azure-fs-hadoop/
+
+RUN mkdir -p /checkpoints && chmod 777 /checkpoints
+
+USER flink

--- a/SerializationErrorCatch/README.md
+++ b/SerializationErrorCatch/README.md
@@ -109,16 +109,7 @@ When developing your job you can run/debug it like any other Java application by
   - KAFKA_TOKEN_URL=http://localhost:1752/oauth2/token
   - KAFKA_SECURITY_PROTOCOL=SASL_PLAINTEXT
   ```
-  You can insert the following string in the `Environment variables` field:
-
-  ```text
-  KAFKA_CLIENT_ID=flink;KAFKA_CLIENT_SECRET=testsecret;KAFKA_TOKEN_URL=http://localhost:1752/oauth2/token;KAFKA_SECURITY_PROTOCOL=SASL_PLAINTEXT
-  ```
-1. Notice how the job is configured to consume events from topic `SerializationErrorCatchInputTopic` and output to `SerializationErrorCatchOutputTopic`
-1. Save configuration by clicking OK
-  > [!IMPORTANT]
-  > When running the job you might see a warning in the console informing that *An illegal reflective access operation has occurred*, which can be ignored.
-
+  
 ## Tests
 ### Unit tests
 
@@ -154,7 +145,7 @@ You can observe the topics and produced messages at [http://localhost:9898](http
 
 You might encounter failing component tests due to your job receiving more messages than expected. This occurs if you've previously run the job and component tests and data is still present in Kafka. The component test will then, in some cases, re-read the output of previous runs.
 
-To fix this, you'll need to delete the data in Kafka by running: `docker compose down` in the `cheetah-development-infrastructure` repository and then starting it again using the command in [Local development with docker-compose](#local-development-with-docker-compose). This deletes the volume containing Kafka's data and starts everything up again.
+To fix this, you'll need to delete the data in Kafka by running: `docker compose down` in the `cheetah-development-infrastructure` repository and then starting it again using the command in [Local development with docker-compose](#local-development). This deletes the volume containing Kafka's data and starts everything up again.
 
 #### Concurrent tests
 

--- a/SerializationErrorCatch/README.md
+++ b/SerializationErrorCatch/README.md
@@ -1,0 +1,197 @@
+ # SerializationErrorCatch
+
+This repository contains a templated flink job. Processing is handled by Apache Flink which is a statefull scalable stream processing framework. You can find more information about Apache Flink [here](https://flink.apache.org/).
+
+The flink job consumes messages from a kafka topic with simple messages, enriches these messages and publishes the enriched messages on another kafka topic.
+
+## Project structure
+
+The following list explains some of the major components of the project, in order to familiarize newcomers with the structure:
+
+- `/src` - Java source code containing the Flink job
+  - `main` - Source code for the job itself
+  - `test` - Unit tests for the job
+- `/ComponentTest` - .NET test project, which is used for component testing the Flink job
+  - `Dockerfile` - to allow testing within Docker
+- `Dockerfile` - for building the Flink job.
+- `docker-compose.yaml` - allows running the Flink job and component test within Docker, with necessary environment values, port bindings, etc. for local development.
+- `pom.xml` - Project Object Model, which defines how to build the Flink job, which dependencies it requires and necessary plugins for building and testing.
+- `README.md` - This file
+- `settings.xml` - Settings file used to configure access to the Maven Package Repository.
+
+## Prerequisites
+
+This project depends on maven packages that are located on the
+Cheetah Maven Repository on github,
+and thus requires access to the Cheetah Maven Repository on Github.
+To enable access you need to get create a personal token by going to
+[https://github.com/settings/tokens/new](https://github.com/settings/tokens/new)
+and creating a token with the `read:packages` scope.
+
+To run the docker containers you need to set the following environment variables:
+
+```bash
+export GITHUB_ACTOR=your-github-username # replace with your github username
+export GITHUB_TOKEN=your-github-token # replace with the token you generated in the previous paragraph
+```
+
+Then verify that you're able to build docker images by running:
+
+```bash
+docker compose build
+```
+
+## Local development
+
+For local development, you will need to clone the [cheetah-development-infrastructure](https://github.com/trifork/cheetah-development-infrastructure) repository. 
+
+You'll then be able to run necessary infrastructure with the following command from within that repository:
+
+```bash
+docker compose up kafka cheetah.oauth.simulator redpanda -d
+```
+
+This will start `kafka`, an `oauth` simulator and `redpanda`, which can be used to inspect what topics and messages exist in `kafka`. 
+
+Redpanda can be accessed on [http://localhost:9898](http://localhost:9898).
+
+You need to create the source topics which the flink job reads from. This is done by setting the `INITIAL_KAFKA_TOPICS` to `SerializationErrorCatchInputTopic SerializationErrorCatchOutputTopic` before running the `kafka-setup` container in `cheetah-development-infrastructure`:
+```powershell
+$env:INITIAL_KAFKA_TOPICS="SerializationErrorCatchInputTopic SerializationErrorCatchOutputTopic"; docker compose up kafka-setup -d
+```
+The `kafka-setup` service is also run when starting kafka using the above command, but running it seperately enables you to create the topics with an already running Kafka.
+Alternatively you can create the topics manually in Redpanda.
+
+`cheetah-development-infrastructure` contains more than just the services that the above command starts, but running the entire infrastructure setup takes up a fair amount of resources on your local system. 
+
+If you need to run other services like OpenSearch, please see the documentation in the `development-infrastructure` repository.
+
+## Inspect and modify using Intellij
+
+When developing your job you can run/debug it like any other Java application by running the `main` method in SerializationErrorCatchJob.
+
+1. Configure the project to use JDK 11: File > Project Structure: Project > Project SDK: 11
+
+1. Verify that the project builds by pressing `Ctrl + F9`
+    > [!WARNING]
+    > If either the project does not build or your Intellij is showing errors in the file, try syncing your maven projects by unfolding the Maven window (by default the top tab in the small vertical bar on the right of the IDE) and pressing the "Reload All Maven Projects"-button in the top-left of that window, then, restart Intellij.
+    > The very first build can take a while, as maven builds up its cache.
+
+1. Navigate to the file `SerializationErrorCatchJob.java`, under the `src/main/java/cheetah/example/serializationerrorcatch/job/` folder.
+1. This file contains a job that performs a mapping on all incoming `InputEvents`. It consists of the following pieces:
+    <details>
+    <!-- Have an empty line after the <details> tag or markdown blocks will not render. -->
+
+    - A static main method, which is used to start the job itself.
+    - A setup method, which is where the main functionality resides. It sets up:
+      - A source - Determines which input source to use, in this case Kafka, and how to connect to it.
+      - An input stream - Specifies the datatype that is ingested from the source, which in this case is `InputEvent`
+      - An output stream - This is where we transform the incoming data - in this case we apply a basic mapping from `InputEvent` to `OutputEvent`. It also determines the output datatype, which in this case is `OutputEvent`
+      - A sink - Determines the destination to output the results of our job to, in this case Kafka
+      - A single call that connects the output stream to the sink
+    </details>
+
+1. Create Intellij run profile for SerializationErrorCatchJob.java with parameters, by right-clicking the file `SerializationErrorCatchJob` and select `Modify Run Configuration...`.
+1. Enter the following program arguments:
+
+  ```
+  --kafka-bootstrap-servers localhost:9092
+  --input-kafka-topic SerializationErrorCatchInputTopic
+  --output-kafka-topic SerializationErrorCatchOutputTopic
+  --kafka-group-id SerializationErrorCatch-group-id
+  ```
+
+  And add the following Environment variables:
+
+  ```
+  - KAFKA_CLIENT_ID=flink
+  - KAFKA_CLIENT_SECRET=testsecret
+  - KAFKA_TOKEN_URL=http://localhost:1752/oauth2/token
+  - KAFKA_SECURITY_PROTOCOL=SASL_PLAINTEXT
+  ```
+  You can insert the following string in the `Environment variables` field:
+
+  ```text
+  KAFKA_CLIENT_ID=flink;KAFKA_CLIENT_SECRET=testsecret;KAFKA_TOKEN_URL=http://localhost:1752/oauth2/token;KAFKA_SECURITY_PROTOCOL=SASL_PLAINTEXT
+  ```
+1. Notice how the job is configured to consume events from topic `SerializationErrorCatchInputTopic` and output to `SerializationErrorCatchOutputTopic`
+1. Save configuration by clicking OK
+  > [!IMPORTANT]
+  > When running the job you might see a warning in the console informing that *An illegal reflective access operation has occurred*, which can be ignored.
+
+## Tests
+### Unit tests
+
+This project contains a sample Unit test in `src/test/java/cheetah/example/serializationerrorcatch/job/SerializationErrorCatchMapperTest.java`, which utilizes JUnit5.
+
+Unit tests are automatically run as part of the build processing when building the Flink job through either `mvn`, Intellij or Docker.
+
+### Component test
+
+This project contains a .NET test project under `/ComponentTest`, which you can use to verify that your job acts as you expect it to.
+
+You can run both these tests from your preferred IDE using the `.sln` file and through docker.
+
+In order to run both your job and the component tests at once, simply run `docker compose up --build` from the root directory of the repository.
+
+Alternatively, if you just want to run your job from docker compose and run the component tests manually through your IDE, run the following command:
+
+```sh
+docker compose up serializationerrorcatch-jobmanager serializationerrorcatch-taskmanager --build
+```
+
+Similarly, you can run just the component test through docker compose using:
+```sh
+docker compose up serializationerrorcatch-test --build
+```
+
+If doing so, make sure to run your job locally from Intellij before starting the component test.
+
+The component test is producing a single message to `SerializationErrorCatchInputTopic`, and listening for any messages published to `SerializationErrorCatchOutputTopic`. It expects the flink job to publish the same message, enriched with a new field, on `SerializationErrorCatchOutputTopic`.
+You can observe the topics and produced messages at [http://localhost:9898](http://localhost:9898).
+
+#### Persisted data during development
+
+You might encounter failing component tests due to your job receiving more messages than expected. This occurs if you've previously run the job and component tests and data is still present in Kafka. The component test will then, in some cases, re-read the output of previous runs.
+
+To fix this, you'll need to delete the data in Kafka by running: `docker compose down` in the `cheetah-development-infrastructure` repository and then starting it again using the command in [Local development with docker-compose](#local-development-with-docker-compose). This deletes the volume containing Kafka's data and starts everything up again.
+
+#### Concurrent tests
+
+While .NET allows running multiple tests in parallel, it is generally a difficult task to ensure that a Flink job correctly handles receiving data intended for testing multiple different "scenarios" at once.
+
+This is a fairly complicated topic to explain accurately, which involves both the way Flink handles incoming messages and how time progresses from the perspective of a Flink Job. The Flink documentation is generally good at explaining many of these nuances - A solid place to start would be: [Timely Stream Processing | Apache Flink](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/concepts/time/).
+
+The general recommendation is to avoid running multiple component tests at the same time. You _may_ be able to run multiple tests in succession, but, depending on the implementation and requirements of both the job and the test, your mileage may wary.
+
+Because of this component testing should, in most scenarios, be kept to testing the job generally (primary functionality, correct input/output models, etc.) while ensuring the finer details of the implementation with unit tests.
+
+# Implementing a new Flink job
+
+## What is a job?
+
+A job in Flink consists of a number of sources, a number of sinks, and a number of transformation steps.
+
+From each source you will get a stream. This stream can be transformed, split, or combined with other streams. Each transformation will take a stream as input and return a stream that can be used as an input for another transformation or sent to a sink.
+
+Some process functions (transformation) can combine two sources. By specifying a common property in `keyBy` it is ensured that related events from the two sources will run in the same thread and have access to the same state. An example could be data enrichment where a main stream is combined with a secondary stream, returning a new stream enriched by data from the secondary stream.
+
+Besides the main stream returned from a process function, some type of functions can generate side outputs which will generate secondary streams that can be consumed by other transformations or sinks. This allows for functions to generate multiple events from a single event.
+
+![example of dataflow](./images/program_dataflow.svg)
+
+## KISS
+
+The job should have minimum responsibility and business logic. Better to have multiple, simple jobs with a small amount of responsibility, than a single, complex job.
+
+In most scenarios, output data should be stored in a Kafka topic. This makes it possible for others to consume the data your job outputs. 
+
+If data needs to be persisted in a database for direct query by some other service, this should be done by the standard storage job.
+
+## TDD
+
+An approach proven to be good, is to start by writing a unit test for the processing job under development.
+Then proceed in micro iterations, carefully assert expected output and behavior.
+The project includes several examples for JUnit tests.
+
+It is not recommended to use Mockto, since Flink is not happy about it and will produce unstable results.

--- a/SerializationErrorCatch/docker-compose.yaml
+++ b/SerializationErrorCatch/docker-compose.yaml
@@ -1,0 +1,100 @@
+version: "3"
+services:
+  serializationerrorcatch-test:
+    build:
+      context: ComponentTest
+      dockerfile: Dockerfile
+      secrets:
+        - GITHUB_TOKEN
+        - GITHUB_ACTOR
+    environment:
+      KAFKA__URL: kafka:19092
+      KAFKA__CLIENTID: ClientId
+      KAFKA__CLIENTSECRET: 1234
+      KAFKA__AUTHENDPOINT: http://cheetahoauthsimulator/oauth2/token
+    depends_on:
+      serializationerrorcatch-jobmanager:
+        condition: service_healthy
+
+  serializationerrorcatch-jobmanager:
+    image: ${DOCKER_REGISTRY-}serializationerrorcatch-job
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - MAVEN_ARGS=${EXTRA_MAVEN_ARGS-}
+      secrets:
+        - GITHUB_TOKEN
+        - GITHUB_ACTOR
+    command: |
+      standalone-job
+      --job-classname cheetah.example.serializationerrorcatch.job.SerializationErrorCatchJob
+      --kafka-bootstrap-servers kafka:19092
+      --input-kafka-topic SerializationErrorCatchInputTopic
+      --output-kafka-topic SerializationErrorCatchOutputTopic
+      --kafka-group-id SerializationErrorCatch-group-id
+      --kafka-security-protocol SASL_PLAINTEXT
+    environment:
+      KAFKA_CLIENT_ID: ClientId
+      KAFKA_CLIENT_SECRET: 1234
+      KAFKA_TOKEN_URL: http://cheetahoauthsimulator/oauth2/token
+      FLINK_PROPERTIES: |
+        jobmanager.rpc.address: serializationerrorcatch-jobmanager
+        scheduler-mode: reactive
+        rest.flamegraph.enabled: true
+        state.backend: rocksdb
+        state.checkpoints.dir: file:///checkpoints/processing
+        state.savepoints.dir: file:///checkpoints/processing
+        execution.checkpointing.interval: 300 seconds
+        execution.checkpointing.min-pause: 240 seconds
+        metrics.reporters: prom
+        metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+    depends_on:
+      - serializationerrorcatch-taskmanager
+    ports:
+      - "18081:8081"
+    volumes:
+      - flink:/checkpoints
+    healthcheck:
+      test: curl localhost:8081/jobs | grep -q '"status":"RUNNING"' || exit -1
+      interval: 1s
+      timeout: 1s
+      retries: 30
+
+  serializationerrorcatch-taskmanager:
+    image: ${DOCKER_REGISTRY-}serializationerrorcatch-job
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - MAVEN_ARGS=${EXTRA_MAVEN_ARGS-}
+      secrets:
+        - GITHUB_TOKEN
+        - GITHUB_ACTOR
+    command: taskmanager
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: serializationerrorcatch-jobmanager
+        taskmanager.memory.process.size: 4gb
+        taskmanager.numberOfTaskSlots: 2
+        metrics.reporters: prom
+        metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+    ports:
+      - "9249:9249"
+    volumes:
+      - flink:/checkpoints
+
+volumes:
+  flink:
+
+secrets:
+  GITHUB_TOKEN:
+    environment: GITHUB_TOKEN
+  GITHUB_ACTOR:
+    environment: GITHUB_ACTOR
+
+networks:
+  default:
+    name: "cheetah-infrastructure"
+    external: true

--- a/SerializationErrorCatch/images/program_dataflow.svg
+++ b/SerializationErrorCatch/images/program_dataflow.svg
@@ -1,0 +1,595 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0beta1 (d565813, 2019-09-28)"
+   sodipodi:docname="program_dataflow.svg"
+   id="svg2"
+   height="495.70895"
+   width="632.86151"
+   version="1.1">
+     <style>svg { background-color: white; }</style>
+  <sodipodi:namedview
+     inkscape:current-layer="g2989"
+     inkscape:window-maximized="0"
+     inkscape:window-y="23"
+     inkscape:window-x="0"
+     inkscape:cy="120.70756"
+     inkscape:cx="148.92077"
+     inkscape:zoom="4"
+     showgrid="false"
+     id="namedview104"
+     inkscape:window-height="1389"
+     inkscape:window-width="2146"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     inkscape:document-rotation="0"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-24.15625,-20.40625)"
+     id="g2989"
+     style="opacity:1;stop-opacity:1">
+    <text
+       x="571.35248"
+       y="45.804131"
+       id="text2991"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Source</text>
+    <text
+       x="25.304533"
+       y="37.765511"
+       id="text2993"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">DataStream</text>
+    <text
+       x="107.97513"
+       y="37.765511"
+       id="text2995"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&lt;</text>
+    <text
+       x="116.22718"
+       y="37.765511"
+       id="text2997"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#5b9bd5">String</text>
+    <text
+       x="166.0396"
+       y="37.765511"
+       id="text2999"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&gt; </text>
+    <text
+       x="182.69376"
+       y="37.765511"
+       id="text3001"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">lines = </text>
+    <text
+       x="248.86023"
+       y="37.765511"
+       id="text3003"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">env.</text>
+    <text
+       x="282.01849"
+       y="37.765511"
+       id="text3005"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">addSource</text>
+    <text
+       x="356.58704"
+       y="37.765511"
+       id="text3007"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(</text>
+    <text
+       x="282.01849"
+       y="54.269619"
+       id="text3009"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#2f5597">new</text>
+    <text
+       x="315.17673"
+       y="54.269619"
+       id="text3011"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">FlinkKafkaConsumer</text>
+    <text
+       x="464.3139"
+       y="54.269619"
+       id="text3013"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&lt;&gt;(…));</text>
+    <text
+       x="25.304533"
+       y="87.277847"
+       id="text3015"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">DataStream</text>
+    <text
+       x="107.97513"
+       y="87.277847"
+       id="text3017"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&lt;</text>
+    <text
+       x="116.22718"
+       y="87.277847"
+       id="text3019"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#5b9bd5">Event</text>
+    <text
+       x="157.78754"
+       y="87.277847"
+       id="text3021"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&gt; events = </text>
+    <text
+       x="248.86023"
+       y="87.277847"
+       id="text3023"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">lines.</text>
+    <text
+       x="298.52261"
+       y="87.277847"
+       id="text3025"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">map</text>
+    <text
+       x="323.57883"
+       y="87.277847"
+       id="text3027"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">((line) </text>
+    <text
+       x="389.7453"
+       y="87.277847"
+       id="text3029"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#2f5597">-</text>
+    <text
+       x="397.99738"
+       y="87.277847"
+       id="text3031"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#2f5597">&gt;</text>
+    <text
+       x="414.50146"
+       y="87.277847"
+       id="text3033"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">parse</text>
+    <text
+       x="456.06183"
+       y="87.277847"
+       id="text3035"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(line));</text>
+    <text
+       x="25.304533"
+       y="120.28607"
+       id="text3037"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">DataStream</text>
+    <text
+       x="107.97513"
+       y="120.28607"
+       id="text3039"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&lt;</text>
+    <text
+       x="116.22718"
+       y="120.28607"
+       id="text3041"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#5b9bd5">Statistics</text>
+    <text
+       x="199.19786"
+       y="120.28607"
+       id="text3043"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&gt; stats = events</text>
+    <text
+       x="91.471016"
+       y="136.79018"
+       id="text3045"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">.</text>
+    <text
+       x="99.723068"
+       y="136.79018"
+       id="text3047"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">keyBy</text>
+    <text
+       x="141.13339"
+       y="136.41518"
+       id="text3049"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(</text>
+    <text
+       x="149.38544"
+       y="136.79018"
+       id="text3051"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#548235"><tspan
+         id="tspan104"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.8034px;font-family:'Courier New';-inkscape-font-specification:'Courier New Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#333333">event</tspan><tspan
+         id="tspan106"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.8034px;font-family:'Courier New';-inkscape-font-specification:'Courier New Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"> <tspan
+   id="tspan939"
+   style="fill:#1a1a1a">-&gt; event.id</tspan></tspan></text>
+    <text
+       x="290.69376"
+       y="136.41518"
+       id="text3053"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">)</text>
+    <text
+       x="91.471016"
+       y="153.2943"
+       id="text3055"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">.</text>
+    <text
+       x="99.723068"
+       y="153.2943"
+       id="text3057"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">timeWindow</text>
+    <text
+       x="182.69376"
+       y="153.2943"
+       id="text3059"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(</text>
+    <text
+       x="190.94582"
+       y="153.2943"
+       id="text3061"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">Time.seconds</text>
+    <text
+       x="290.27054"
+       y="153.2943"
+       id="text3063"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(10))</text>
+    <text
+       x="91.471016"
+       y="169.79842"
+       id="text3065"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">.</text>
+    <text
+       x="99.723068"
+       y="169.79842"
+       id="text3067"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">apply</text>
+    <text
+       x="141.13339"
+       y="169.79842"
+       id="text3069"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(</text>
+    <text
+       x="149.38544"
+       y="169.79842"
+       id="text3071"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#2f5597">new</text>
+    <text
+       x="182.69376"
+       y="169.79842"
+       id="text3073"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">MyWindowAggregationFunction</text>
+    <text
+       x="406.24942"
+       y="169.79842"
+       id="text3075"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">());</text>
+    <text
+       x="25.304533"
+       y="202.2049"
+       id="text3077"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">stats.</text>
+    <text
+       x="74.816864"
+       y="202.62952"
+       id="text3079"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">addSink</text>
+    <text
+       x="132.88133"
+       y="202.80663"
+       id="text3081"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(</text>
+    <text
+       x="141.13339"
+       y="202.16539"
+       id="text3083"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#2f5597">new</text>
+    <text
+       x="174.4417"
+       y="202.19572"
+       id="text3085"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">MySink</text>
+    <text
+       x="221.16571"
+       y="202.05418"
+       id="text3087"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(...));</text>
+    <path
+       d="m 32.445583,379.40702 c 0,-17.70441 14.309815,-32.05174 31.957962,-32.05174 17.648146,0 31.957961,14.34733 31.957961,32.05174 0,17.68566 -14.309815,32.03298 -31.957961,32.03298 -17.648147,0 -31.957962,-14.34732 -31.957962,-32.03298"
+       id="path3089"
+       style="fill:#ffd966;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <text
+       x="46.974251"
+       y="383.34982"
+       id="text3091"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Source</text>
+    <path
+       d="m 170.44246,379.40702 c 0,-17.70441 14.34733,-32.05174 32.03298,-32.05174 17.70441,0 32.05174,14.34733 32.05174,32.05174 0,17.68566 -14.34733,32.03298 -32.05174,32.03298 -17.68565,0 -32.03298,-14.34732 -32.03298,-32.03298"
+       id="path3093"
+       style="fill:#ffd966;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <text
+       x="187.06161"
+       y="383.34982"
+       id="text3095"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">map()</text>
+    <path
+       d="m 104.1822,375.18722 h 50.16875 v -4.2198 l 8.43961,8.4396 -8.43961,8.4396 v -4.2198 H 104.1822 Z"
+       id="path3097"
+       style="fill:#bfbfbf;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 532.55767,21.023988 c 4.93248,0 8.90847,0.675168 8.90847,1.500373 v 17.49811 c 0,0.825205 3.99475,1.481619 8.90847,1.481619 -4.91372,0 -8.90847,0.675168 -8.90847,1.481619 v 17.516864 c 0,0.806451 -3.97599,1.481619 -8.90847,1.481619"
+       id="path3099"
+       style="fill:none;stroke:#000000;stroke-width:1.25656px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 532.55767,70.573832 c 4.93248,0 8.90847,0.675168 8.90847,1.481619 v 9.771184 c 0,0.825206 3.99475,1.481619 8.90847,1.481619 -4.91372,0 -8.90847,0.675168 -8.90847,1.481619 v 9.771185 c 0,0.825205 -3.97599,1.481619 -8.90847,1.481619"
+       id="path3101"
+       style="fill:none;stroke:#000000;stroke-width:1.25656px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 532.08881,104.65107 c 4.93248,0 8.90847,0.65641 8.90847,1.48162 v 33.83343 c 0,0.8252 3.99474,1.48162 8.90847,1.48162 -4.91373,0 -8.90847,0.67517 -8.90847,1.48162 v 33.85218 c 0,0.80645 -3.97599,1.48162 -8.90847,1.48162"
+       id="path3103"
+       style="fill:none;stroke:#000000;stroke-width:1.25656px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 532.08881,188.2594 c 4.93248,0 8.90847,0.67517 8.90847,1.48162 v 9.62115 c 0,0.8252 3.99474,1.48162 8.90847,1.48162 -4.91373,0 -8.90847,0.65641 -8.90847,1.48161 v 9.62115 c 0,0.80645 -3.97599,1.48162 -8.90847,1.48162"
+       id="path3105"
+       style="fill:none;stroke:#000000;stroke-width:1.25656px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <text
+       x="571.35248"
+       y="86.226501"
+       id="text3107"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Transformation</text>
+    <text
+       x="571.35248"
+       y="145.72234"
+       id="text3109"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Transformation</text>
+    <text
+       x="94.209488"
+       y="313.34818"
+       id="text3111"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Source</text>
+    <text
+       x="88.508072"
+       y="326.85153"
+       id="text3113"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Operator</text>
+    <path
+       d="m 242.17908,375.18722 h 50.16875 v -4.2198 l 8.4396,8.4396 -8.4396,8.4396 v -4.2198 h -50.16875 z"
+       id="path3115"
+       style="fill:#bfbfbf;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 308.43934,379.40702 c 0,-17.70441 14.34732,-32.05174 32.05173,-32.05174 17.68566,0 32.03299,14.34733 32.03299,32.05174 0,17.68566 -14.34733,32.03298 -32.03299,32.03298 -17.70441,0 -32.05173,-14.34732 -32.05173,-32.03298"
+       id="path3117"
+       style="fill:#ffd966;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <text
+       x="318.24503"
+       y="371.34683"
+       id="text3119"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">keyBy</text>
+    <text
+       x="349.15274"
+       y="371.34683"
+       id="text3121"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">()/</text>
+    <text
+       x="314.79416"
+       y="383.34982"
+       id="text3123"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">window()/</text>
+    <text
+       x="322.29605"
+       y="395.35281"
+       id="text3125"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">apply()</text>
+    <path
+       d="m 380.17596,375.18722 h 50.16875 v -4.2198 l 8.4396,8.4396 -8.4396,8.4396 v -4.2198 h -50.16875 z"
+       id="path3127"
+       style="fill:#bfbfbf;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 446.45497,379.40702 c 0,-17.70441 14.34733,-32.05174 32.03298,-32.05174 17.70441,0 32.03298,14.34733 32.03298,32.05174 0,17.68566 -14.32857,32.03298 -32.03298,32.03298 -17.68565,0 -32.03298,-14.34732 -32.03298,-32.03298"
+       id="path3129"
+       style="fill:#ffd966;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <text
+       x="467.4761"
+       y="383.34982"
+       id="text3131"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Sink</text>
+    <path
+       d="m 240.45365,250.46865 h 17.01049 v -16.2603 h 33.98347 v 16.2603 h 16.99173 l -33.98347,16.24154 z"
+       id="path3133"
+       style="fill:none;stroke:#000000;stroke-width:1.25656px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <text
+       x="227.00369"
+       y="313.34818"
+       id="text3135"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Transformation</text>
+    <text
+       x="242.00743"
+       y="326.85153"
+       id="text3137"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Operators</text>
+    <text
+       x="438.99158"
+       y="313.34818"
+       id="text3139"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Sink</text>
+    <text
+       x="426.08835"
+       y="326.85153"
+       id="text3141"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Operator</text>
+    <path
+       d="m 451.65002,333.72064 5.6264,8.21454 -1.03151,0.69393 -5.6264,-8.19579 z m 6.4516,6.11402 0.76895,5.53263 -4.89497,-2.70067 z"
+       id="path3143"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 89.591069,331.58261 -4.688668,8.04575 1.069017,0.63766 4.688668,-8.06451 z m -5.682665,6.02025 -0.356339,5.58889 4.669913,-3.07577 z"
+       id="path3145"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 234.03956,329.40706 -12.92197,12.80944 0.88147,0.88147 12.92196,-12.79068 z m -13.35333,10.59639 -1.80045,5.28882 5.32633,-1.74418 z"
+       id="path3147"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 301.21879,329.40706 15.51012,14.72242 -0.86272,0.90023 -15.51011,-14.72242 z m 15.88521,12.49062 1.91298,5.27006 -5.34509,-1.63166 z"
+       id="path3149"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 241.72897,447.91784 -87.19047,-54.5761 0.65641,-1.06902 87.20923,54.5761 z m -87.13421,-52.32554 -2.90697,-4.78244 5.57014,0.54389 z"
+       id="path3151"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <text
+       x="245.67148"
+       y="463.08081"
+       id="text3153"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Stream</text>
+    <path
+       d="m 291.37259,447.9741 102.90688,-49.34354 -0.54388,-1.12528 -102.90689,49.34354 z m 102.58806,-47.11174 3.41335,-4.4261 -5.5889,-0.0938 2.17555,4.51987 z"
+       id="path3155"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 270.77996,440.92234 v -39.79741 h -1.25656 v 39.79741 z m 1.87547,-38.54085 -2.49438,-5.00749 -2.51312,5.00749 z"
+       id="path3157"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <text
+       x="571.35248"
+       y="205.12807"
+       id="text3159"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Sink</text>
+    <path
+       d="m 516.93503,463.33418 c 0,8.15828 -1.10652,14.75993 -2.45686,14.75993 H 273.33059 c -1.36909,0 -2.47561,6.62039 -2.47561,14.77868 0,-8.15829 -1.08777,-14.77868 -2.45687,-14.77868 H 27.250539 c -1.369091,0 -2.475617,-6.60165 -2.475617,-14.75993"
+       id="path3161"
+       style="fill:none;stroke:#000000;stroke-width:1.25656px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <text
+       x="214.03168"
+       y="513.79102"
+       id="text3163"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Streaming Dataflow</text>
+    <text
+       x="-125.25892"
+       y="179.02612"
+       transform="translate(24.15625,20.40625)"
+       id="text3257"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"><tspan
+         x="-125.25892"
+         y="179.02612"
+         id="tspan3259" /></text>
+  </g>
+</svg>

--- a/SerializationErrorCatch/pom.xml
+++ b/SerializationErrorCatch/pom.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>cheetah.example.serializationerrorcatch</groupId>
+    <artifactId>SerializationErrorCatch</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>SerializationErrorCatch Flink Job</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <flink.version>1.16.1</flink.version>
+        <target.java.version>11</target.java.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <maven.compiler.source>${target.java.version}</maven.compiler.source>
+        <maven.compiler.target>${target.java.version}</maven.compiler.target>
+        <log4j.version>2.21.1</log4j.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>apache.snapshots</id>
+            <name>Apache Development Snapshot Repository</name>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/trifork/cheetah-lib-processing</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.trifork.cheetah.processing</groupId>
+            <artifactId>cheetah-lib-processing</artifactId>
+            <version>3.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.2</version>
+            </plugin>
+            <!-- Java Compiler -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.30</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <source>${target.java.version}</source>
+                    <target>${target.java.version}</target>
+                </configuration>
+            </plugin>
+
+            <!-- We use the maven-shade plugin to create a fat jar that contains all necessary dependencies. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <!-- Run shade goal on package phase -->
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.apache.flink:flink-shaded-force-shading</exclude>
+                                    <exclude>com.google.code.findbugs:jsr305</exclude>
+                                    <exclude>org.slf4j:*</exclude>
+                                    <exclude>org.apache.logging.log4j:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <!-- Do not copy the signatures in the META-INF folder.
+                                    Otherwise, this might cause SecurityExceptions when using the JAR. -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <includeScope>runtime</includeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Creates the jar and configures classpath to use lib folder -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <!-- Java Compiler -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${target.java.version}</source>
+                    <target>${target.java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/SerializationErrorCatch/settings.xml
+++ b/SerializationErrorCatch/settings.xml
@@ -1,0 +1,10 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>github</id>
+            <username>${env.GITHUB_ACTOR}</username>
+            <password>${env.GITHUB_TOKEN}</password>
+        </server>
+    </servers>
+</settings>

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/DeserializationSchema.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/DeserializationSchema.java
@@ -14,6 +14,7 @@ public class DeserializationSchema<T> extends JsonDeserializationSchema<T> {
     public DeserializationSchema(Class<T> clazz) {
         super(clazz);
     }
+
     @Override
     public T deserialize(byte[] message) {
         try {
@@ -23,6 +24,7 @@ public class DeserializationSchema<T> extends JsonDeserializationSchema<T> {
             return null;
         }
     }
+
     @Override
     public void deserialize(byte[] message, Collector<T> out)  {
         T deserialize = deserialize(message);

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/DeserializationSchema.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/DeserializationSchema.java
@@ -1,0 +1,23 @@
+package cheetah.example.serializationerrorcatch.function;
+
+import cheetah.example.serializationerrorcatch.model.InputEvent;
+import org.apache.flink.formats.json.JsonDeserializationSchema;
+
+import java.io.IOException;
+
+public class DeserializationSchema<T> extends JsonDeserializationSchema<T> {
+
+    public DeserializationSchema(Class<T> clazz) {
+        super(clazz);
+    }
+    @Override
+    public T deserialize(byte[] message) {
+        try {
+            return super.deserialize(message);
+        } catch (IOException e) {
+            System.out.println("The message failed to be serialized with error message =>" + e);
+            return (T) new InputEvent();
+        }
+
+    }
+}

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/DeserializationSchema.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/DeserializationSchema.java
@@ -2,9 +2,13 @@ package cheetah.example.serializationerrorcatch.function;
 
 import cheetah.example.serializationerrorcatch.model.InputEvent;
 import org.apache.flink.formats.json.JsonDeserializationSchema;
+import org.apache.flink.util.Collector;
 
 import java.io.IOException;
 
+/** DeserializationSchema is a custom deserialization schema that extends the JsonDeserializationSchema.
+ * It is used to catch deserialization errors and handle them in a tailored manner.
+ * In this case, it returns null if the deserialization fails and logs an error message. */
 public class DeserializationSchema<T> extends JsonDeserializationSchema<T> {
 
     public DeserializationSchema(Class<T> clazz) {
@@ -15,9 +19,13 @@ public class DeserializationSchema<T> extends JsonDeserializationSchema<T> {
         try {
             return super.deserialize(message);
         } catch (IOException e) {
-            System.out.println("The message failed to be serialized with error message =>" + e);
-            return (T) new InputEvent();
+            System.out.println("The message failed to be serialized with error message => " + e);
+            return null;
         }
-
+    }
+    @Override
+    public void deserialize(byte[] message, Collector<T> out)  {
+        T deserialize = deserialize(message);
+        out.collect(deserialize);
     }
 }

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/FilterAndCountFailedSerializations.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/FilterAndCountFailedSerializations.java
@@ -2,6 +2,7 @@ package cheetah.example.serializationerrorcatch.function;
 
 import cheetah.example.serializationerrorcatch.model.InputEvent;
 import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Gauge;
 
 /** FilterAndCountFailedSerializations is a RichFilterFunction that checks if the DeviceId from in the message is null.
@@ -11,13 +12,16 @@ public class FilterAndCountFailedSerializations extends RichFilterFunction<Input
     private transient int messagesFailed = 0;
 
     @Override
-    public boolean filter(InputEvent value) {
+    public void open(Configuration parameters) throws Exception {
+        getRuntimeContext()
+                .getMetricGroup()
+                .gauge("FailedMessagesProcessed", (Gauge<Integer>) () -> messagesFailed);
+    }
 
+    @Override
+    public boolean filter(InputEvent value) {
         if (value == null) {
             messagesFailed++;
-            getRuntimeContext()
-                    .getMetricGroup()
-                    .gauge("FailedMessagesProcessed", (Gauge<Integer>) () -> messagesFailed);
             return false;
         }
         return true;

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/FilterAndCountFailedSerializations.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/FilterAndCountFailedSerializations.java
@@ -1,0 +1,22 @@
+package cheetah.example.serializationerrorcatch.function;
+
+import cheetah.example.serializationerrorcatch.model.InputEvent;
+import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.metrics.Gauge;
+
+public class FilterAndCountFailedSerializations extends RichFilterFunction<InputEvent> {
+    private transient int messagesFailed = 0;
+
+    @Override
+    public boolean filter(InputEvent value) {
+
+        if (value.getDeviceId() == null) {
+            messagesFailed++;
+            getRuntimeContext()
+                    .getMetricGroup()
+                    .gauge("FailedMessagesProcessed", (Gauge<Integer>) () -> messagesFailed);
+            return false;
+        }
+        return true;
+    }
+}

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/FilterAndCountFailedSerializations.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/FilterAndCountFailedSerializations.java
@@ -4,13 +4,16 @@ import cheetah.example.serializationerrorcatch.model.InputEvent;
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.metrics.Gauge;
 
+/** FilterAndCountFailedSerializations is a RichFilterFunction that checks if the DeviceId from in the message is null.
+ * If it is null, it increments a metric counter called "FailedMessagesProcessed" and returns false,
+ * otherwise it returns true */
 public class FilterAndCountFailedSerializations extends RichFilterFunction<InputEvent> {
     private transient int messagesFailed = 0;
 
     @Override
     public boolean filter(InputEvent value) {
 
-        if (value.getDeviceId() == null) {
+        if (value == null) {
             messagesFailed++;
             getRuntimeContext()
                     .getMetricGroup()

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/SerializationErrorCatchMapper.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/SerializationErrorCatchMapper.java
@@ -1,0 +1,23 @@
+package cheetah.example.serializationerrorcatch.function;
+
+import cheetah.example.serializationerrorcatch.model.InputEvent;
+import cheetah.example.serializationerrorcatch.model.OutputEvent;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.metrics.Gauge;
+
+/** SerializationErrorCatchMapper converts from InputEvent to OutputEvent. */
+public class SerializationErrorCatchMapper implements MapFunction<InputEvent, OutputEvent> {
+    private final String extraField;
+
+    public SerializationErrorCatchMapper(final String extraField) {
+        this.extraField = extraField;
+    }
+
+    @Override
+    public OutputEvent map(final InputEvent InputEvent) {
+        return new OutputEvent(InputEvent, extraField);
+    }
+
+}
+

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/SerializationErrorCatchMapper.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/SerializationErrorCatchMapper.java
@@ -15,8 +15,8 @@ public class SerializationErrorCatchMapper implements MapFunction<InputEvent, Ou
     }
 
     @Override
-    public OutputEvent map(final InputEvent InputEvent) {
-        return new OutputEvent(InputEvent, extraField);
+    public OutputEvent map(final InputEvent inputEvent) {
+        return new OutputEvent(inputEvent, extraField);
     }
 
 }

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/SerializationErrorCatchMapper.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/function/SerializationErrorCatchMapper.java
@@ -6,7 +6,7 @@ import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.metrics.Gauge;
 
-/** SerializationErrorCatchMapper converts from InputEvent to OutputEvent. */
+/** SerializationErrorCatchMapper is a simple MapFunction that converts from InputEvent to OutputEvent. */
 public class SerializationErrorCatchMapper implements MapFunction<InputEvent, OutputEvent> {
     private final String extraField;
 

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/job/SerializationErrorCatchJob.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/job/SerializationErrorCatchJob.java
@@ -15,7 +15,9 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 
 import java.io.Serializable;
 
-/** SerializationErrorCatchJob sets up the data processing job. */
+/** The SerializationErrorCatchJob exemplifies the creation of a custom deserialization method,
+ * its integration with the KafkaSource, and the handling of deserialization errors in a tailored manner.
+ * In this demonstration, an error log message is displayed also accompanied by the incrementation of a metric counter. */
 public class SerializationErrorCatchJob extends Job implements Serializable {
 
     @SuppressWarnings("PMD.SignatureDeclareThrowsException") // Fix once lib-processing is fixed

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/job/SerializationErrorCatchJob.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/job/SerializationErrorCatchJob.java
@@ -1,0 +1,46 @@
+package cheetah.example.serializationerrorcatch.job;
+
+import cheetah.example.serializationerrorcatch.function.FilterAndCountFailedSerializations;
+import cheetah.example.serializationerrorcatch.function.SerializationErrorCatchMapper;
+import cheetah.example.serializationerrorcatch.model.InputEvent;
+import cheetah.example.serializationerrorcatch.model.OutputEvent;
+import cheetah.example.serializationerrorcatch.function.DeserializationSchema;
+import com.trifork.cheetah.processing.job.Job;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import com.trifork.cheetah.processing.connector.kafka.CheetahKafkaSink;
+import com.trifork.cheetah.processing.connector.kafka.CheetahKafkaSource;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+
+import java.io.Serializable;
+
+/** SerializationErrorCatchJob sets up the data processing job. */
+public class SerializationErrorCatchJob extends Job implements Serializable {
+
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException") // Fix once lib-processing is fixed
+    public static void main(final String[] args) throws Exception {
+        new SerializationErrorCatchJob().start(args);
+    }
+
+    @Override
+    protected void setup() {
+        // Input source
+        final KafkaSource<InputEvent> kafkaSource = CheetahKafkaSource.builder(InputEvent.class, this)
+                .setValueOnlyDeserializer(new DeserializationSchema<>(InputEvent.class))
+                .build();
+
+        final DataStream<InputEvent> inputStream = CheetahKafkaSource.toDataStream(this, kafkaSource, "SerializationErrorCatch-source");
+
+        // Transform stream
+        final SingleOutputStreamOperator<OutputEvent> outputStream =
+                inputStream.filter(new FilterAndCountFailedSerializations()).map(new SerializationErrorCatchMapper("ExtraFieldValue"));
+
+        // Output sink
+        KafkaSink<OutputEvent> kafkaSink = CheetahKafkaSink.builder(OutputEvent.class, this)
+                .build();
+
+        // Connect transformed stream to sink
+        outputStream.sinkTo(kafkaSink);
+    }
+}

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/job/SerializationErrorCatchJob.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/job/SerializationErrorCatchJob.java
@@ -4,7 +4,7 @@ import cheetah.example.serializationerrorcatch.function.FilterAndCountFailedSeri
 import cheetah.example.serializationerrorcatch.function.SerializationErrorCatchMapper;
 import cheetah.example.serializationerrorcatch.model.InputEvent;
 import cheetah.example.serializationerrorcatch.model.OutputEvent;
-import cheetah.example.serializationerrorcatch.function.DeserializationSchema;
+import cheetah.example.serializationerrorcatch.serde.DeserializationSchema;
 import com.trifork.cheetah.processing.job.Job;
 import org.apache.flink.connector.kafka.sink.KafkaSink;
 import org.apache.flink.connector.kafka.source.KafkaSource;
@@ -35,8 +35,9 @@ public class SerializationErrorCatchJob extends Job implements Serializable {
         final DataStream<InputEvent> inputStream = CheetahKafkaSource.toDataStream(this, kafkaSource, "SerializationErrorCatch-source");
 
         // Transform stream
-        final SingleOutputStreamOperator<OutputEvent> outputStream =
-                inputStream.filter(new FilterAndCountFailedSerializations()).map(new SerializationErrorCatchMapper("ExtraFieldValue"));
+        final SingleOutputStreamOperator<OutputEvent> outputStream = inputStream
+                .filter(new FilterAndCountFailedSerializations())
+                .map(new SerializationErrorCatchMapper("ExtraFieldValue"));
 
         // Output sink
         KafkaSink<OutputEvent> kafkaSink = CheetahKafkaSink.builder(OutputEvent.class, this)

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/model/InputEvent.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/model/InputEvent.java
@@ -1,0 +1,17 @@
+package cheetah.example.serializationerrorcatch.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** InputEvent represents the events to be processed. */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class InputEvent {
+    private String deviceId;
+    private double value;
+    private long timestamp;
+}

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/model/OutputEvent.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/model/OutputEvent.java
@@ -17,6 +17,7 @@ public class OutputEvent {
         this.timestamp = inputEvent.getTimestamp();
         this.extraField = extraFieldValue;
     }
+
     private String deviceId;
     private double value;
     private long timestamp;

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/model/OutputEvent.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/model/OutputEvent.java
@@ -1,0 +1,24 @@
+package cheetah.example.serializationerrorcatch.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** OutputEvent represents the events being generated. */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OutputEvent {
+    public OutputEvent(InputEvent inputEvent, String extraFieldValue){
+        this.deviceId = inputEvent.getDeviceId();
+        this.value = inputEvent.getValue();
+        this.timestamp = inputEvent.getTimestamp();
+        this.extraField = extraFieldValue;
+    }
+    private String deviceId;
+    private double value;
+    private long timestamp;
+    private String extraField;
+}

--- a/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/serde/DeserializationSchema.java
+++ b/SerializationErrorCatch/src/main/java/cheetah/example/serializationerrorcatch/serde/DeserializationSchema.java
@@ -1,8 +1,10 @@
-package cheetah.example.serializationerrorcatch.function;
+package cheetah.example.serializationerrorcatch.serde;
 
 import cheetah.example.serializationerrorcatch.model.InputEvent;
 import org.apache.flink.formats.json.JsonDeserializationSchema;
 import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -10,7 +12,7 @@ import java.io.IOException;
  * It is used to catch deserialization errors and handle them in a tailored manner.
  * In this case, it returns null if the deserialization fails and logs an error message. */
 public class DeserializationSchema<T> extends JsonDeserializationSchema<T> {
-
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     public DeserializationSchema(Class<T> clazz) {
         super(clazz);
     }
@@ -20,7 +22,7 @@ public class DeserializationSchema<T> extends JsonDeserializationSchema<T> {
         try {
             return super.deserialize(message);
         } catch (IOException e) {
-            System.out.println("The message failed to be serialized with error message => " + e);
+            logger.warn("The message failed to be serialized with error message => " + e);
             return null;
         }
     }

--- a/SerializationErrorCatch/src/test/java/cheetah/example/serializationerrorcatch/job/SerializationErrorCatchMapperTest.java
+++ b/SerializationErrorCatch/src/test/java/cheetah/example/serializationerrorcatch/job/SerializationErrorCatchMapperTest.java
@@ -1,0 +1,28 @@
+package cheetah.example.serializationerrorcatch.job;
+
+import cheetah.example.serializationerrorcatch.function.SerializationErrorCatchMapper;
+import cheetah.example.serializationerrorcatch.model.InputEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SerializationErrorCatchMapperTest {
+    private final SerializationErrorCatchMapper mapper = new SerializationErrorCatchMapper("extraFieldValue");
+
+    @Test
+    public void testEnrichment() {
+        final String deviceId = UUID.randomUUID().toString();
+        final double value = 1.0;
+        final long timestamp = 0;
+        final var input = new InputEvent(deviceId, value, timestamp);
+
+        final var actual = mapper.map(input);
+
+        assertEquals(deviceId, actual.getDeviceId());
+        assertEquals(value, actual.getValue());
+        assertEquals(timestamp, actual.getTimestamp());
+        assertEquals("extraFieldValue", actual.getExtraField());
+    }
+}

--- a/SerializationErrorCatch/src/test/java/cheetah/example/serializationerrorcatch/model/SerializationErrorCatchInputEventTest.java
+++ b/SerializationErrorCatch/src/test/java/cheetah/example/serializationerrorcatch/model/SerializationErrorCatchInputEventTest.java
@@ -1,0 +1,23 @@
+package cheetah.example.serializationerrorcatch.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.types.PojoTestUtils.assertSerializedAsPojo;
+import static org.apache.flink.types.PojoTestUtils.assertSerializedAsPojoWithoutKryo;
+
+class InputEventTest {
+    /*
+     This test ensures that the input event class can be serialized without using the Kryo serializer. Similar tests
+     should be implemented for any class that is serialized often, i.e. input/output models, objects that are stored in
+     state, etc.
+
+     Using the Kryo serializer infers a substantial performance decrease compared to alternative serializers, giving
+     reason to this test. This happens most often with generic classes, which cannot usually be serialized with
+     other, more efficient serializers.
+     */
+    @Test
+    void isSerializedAsPojo() {
+        assertSerializedAsPojo(InputEvent.class);
+        assertSerializedAsPojoWithoutKryo(InputEvent.class);
+    }
+}

--- a/SerializationErrorCatch/src/test/java/cheetah/example/serializationerrorcatch/model/SerializationErrorCatchInputEventTest.java
+++ b/SerializationErrorCatch/src/test/java/cheetah/example/serializationerrorcatch/model/SerializationErrorCatchInputEventTest.java
@@ -17,7 +17,6 @@ class InputEventTest {
      */
     @Test
     void isSerializedAsPojo() {
-        assertSerializedAsPojo(InputEvent.class);
         assertSerializedAsPojoWithoutKryo(InputEvent.class);
     }
 }

--- a/SerializationErrorCatch/src/test/java/cheetah/example/serializationerrorcatch/model/SerializationErrorCatchOutputEventTest.java
+++ b/SerializationErrorCatch/src/test/java/cheetah/example/serializationerrorcatch/model/SerializationErrorCatchOutputEventTest.java
@@ -17,7 +17,6 @@ class OutputEventTest {
      */
     @Test
     void isSerializedAsPojo() {
-        assertSerializedAsPojo(OutputEvent.class);
         assertSerializedAsPojoWithoutKryo(OutputEvent.class);
     }
 }

--- a/SerializationErrorCatch/src/test/java/cheetah/example/serializationerrorcatch/model/SerializationErrorCatchOutputEventTest.java
+++ b/SerializationErrorCatch/src/test/java/cheetah/example/serializationerrorcatch/model/SerializationErrorCatchOutputEventTest.java
@@ -1,0 +1,23 @@
+package cheetah.example.serializationerrorcatch.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.types.PojoTestUtils.assertSerializedAsPojo;
+import static org.apache.flink.types.PojoTestUtils.assertSerializedAsPojoWithoutKryo;
+
+class OutputEventTest {
+    /*
+     This test ensures that the input event class can be serialized without using the Kryo serializer. Similar tests
+     should be implemented for any class that is serialized often, i.e. input/output models, objects that are stored in
+     state, etc.
+
+     Using the Kryo serializer infers a substantial performance decrease compared to alternative serializers, giving
+     reason to this test. This happens most often with generic classes, which cannot usually be serialized with
+     other, more efficient serializers.
+     */
+    @Test
+    void isSerializedAsPojo() {
+        assertSerializedAsPojo(OutputEvent.class);
+        assertSerializedAsPojoWithoutKryo(OutputEvent.class);
+    }
+}


### PR DESCRIPTION
This example demonstrates a customized approach to handling deserialization errors, where a log message is presented alongside an incrementing metric counter, as opposed to the of the job throwing an exception and terminating.

To achieve this, a implementation of the Deserialization method extending JsonDeserializationSchema is necessary. This custom method outputs null in the event of a deserialization error, rather than triggering an exception and potentially crashing the job.

The rationale behind returning null from the deserialization method, instead of directly incrementing the metric count, is because we don't have access to the RunTimeContext within the deserialization method. Instead, a RichFilterFunction checks whether the incoming message is null and increments the metric count.

If there exists a more effective approach to accomplish this task, I am open to suggestions. :)